### PR TITLE
Allow responseHandler to update protocol

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -419,6 +419,9 @@ exports.XMLHttpRequest = function() {
             withCredentials: self.withCredentials
           };
 
+          // Update request function if protocol has changed via redirect
+          doRequest = (url.protocol === "https:") ? https.request : http.request;
+          
           // Issue the new request
           request = doRequest(newOptions, responseHandler).on("error", errorHandler);
           request.end();


### PR DESCRIPTION
This fixes the case where an `http` request might be updated to `https` via a redirect or mod_write rule. Currently the `responseHandler` does not check for protocol changes or updates.